### PR TITLE
Disable AC preset mode if only 'off' mode is available

### DIFF
--- a/custom_components/smartthings/climate.py
+++ b/custom_components/smartthings/climate.py
@@ -553,6 +553,16 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
     @property
     def supported_features(self):
         """Return the supported features."""
+        supported_ac_optional_modes = [
+            str(x)
+            for x in self._device.status.attributes["supportedAcOptionalMode"].value
+        ]
+        if len(supported_ac_optional_modes) == 1 and supported_ac_optional_modes[0] == "off":
+            return (
+                SUPPORT_TARGET_TEMPERATURE
+                | SUPPORT_FAN_MODE
+                | SUPPORT_SWING_MODE
+            )
         return (
             SUPPORT_TARGET_TEMPERATURE
             | SUPPORT_FAN_MODE


### PR DESCRIPTION
For my Samsung AC (MIM-h04 Wi-Fi kit for Samsung VRF), I have only 'off' preset mode available.
So there is no need for SUPPORT_PRESET_MODE because it will be always 'off'.