### PR TITLE
fix: number entity refactoring due to changes in home-assistant

### DIFF
--- a/custom_components/smartthings/number.py
+++ b/custom_components/smartthings/number.py
@@ -118,14 +118,14 @@ class SmartThingsNumber(SmartThingsEntity, NumberEntity):
         self._attribute = attribute
         self._command = command
         self._name = name
-        self._attr_unit_of_measurement = unit_of_measurement
+        self._attr_native_unit_of_measurement = unit_of_measurement
         self._icon = icon
-        self._attr_min_value = min_value
-        self._attr_max_value = max_value
-        self._attr_step = step
+        self._attr_native_min_value = min_value
+        self._attr_native_max_value = max_value
+        self._attr_native_step = step
         self._attr_mode = mode
 
-    async def async_set_value(self, value: float) -> None:
+    async def async_set_native_value(self, value: float) -> None:
         """Set the number value."""
         await getattr(self._device, self._command)(int(value), set_status=True)
 
@@ -140,7 +140,7 @@ class SmartThingsNumber(SmartThingsEntity, NumberEntity):
         return f"{self._device.device_id}.{self._attribute}"
 
     @property
-    def value(self) -> float:
+    def native_value(self) -> float:
         """Return  Value."""
         return self._device.status.attributes[self._attribute].value
 
@@ -150,22 +150,22 @@ class SmartThingsNumber(SmartThingsEntity, NumberEntity):
         return self._icon
 
     @property
-    def min_value(self) -> float:
+    def native_min_value(self) -> float:
         """Define mimimum level."""
         return self._attr_min_value
 
     @property
-    def max_value(self) -> float:
+    def native_max_value(self) -> float:
         """Define maximum level."""
         return self._attr_max_value
 
     @property
-    def step(self) -> float:
+    def native_step(self) -> float:
         """Define stepping size"""
         return self._attr_step
 
     @property
-    def unit_of_measurement(self) -> str | None:
+    def native_unit_of_measurement(self) -> str | None:
         """Return unit of measurement"""
         unit = self._device.status.attributes[self._attribute].unit
         return UNIT_MAP.get(unit) if unit else self._attr_unit_of_measurement
@@ -204,7 +204,7 @@ class SamsungOcfTemperatureNumber(SmartThingsEntity, NumberEntity):
         tasks.append(self._device.execute(self._page))
         asyncio.gather(*tasks)
 
-    async def async_set_value(self, value: float) -> None:
+    async def async_set_native_value(self, value: float) -> None:
         """Set the number value."""
         result = await self._device.execute(self._page, {"temperature": value})
         if result:
@@ -233,7 +233,7 @@ class SamsungOcfTemperatureNumber(SmartThingsEntity, NumberEntity):
         return f"{self._device.device_id}.{_unique_id}"
 
     @property
-    def value(self) -> float:
+    def native_value(self) -> float:
         """Return  Value."""
         if not self.init_bool:
             self.startup()
@@ -252,7 +252,7 @@ class SamsungOcfTemperatureNumber(SmartThingsEntity, NumberEntity):
         return "mdi:thermometer-lines"
 
     @property
-    def min_value(self) -> float:
+    def native_min_value(self) -> float:
         """Define mimimum level."""
         if self._device.status.attributes[Attribute.data].data["href"] == self._page:
             self.min_value_state = int(
@@ -263,7 +263,7 @@ class SamsungOcfTemperatureNumber(SmartThingsEntity, NumberEntity):
         return self.min_value_state
 
     @property
-    def max_value(self) -> float:
+    def native_max_value(self) -> float:
         """Define maximum level."""
         if self._device.status.attributes[Attribute.data].data["href"] == self._page:
             self.max_value_state = int(
@@ -274,12 +274,12 @@ class SamsungOcfTemperatureNumber(SmartThingsEntity, NumberEntity):
         return self.max_value_state
 
     @property
-    def step(self) -> float:
+    def native_step(self) -> float:
         """Define stepping size"""
         return 1
 
     @property
-    def unit_of_measurement(self) -> str | None:
+    def native_unit_of_measurement(self) -> str | None:
         """Return unit of measurement"""
         if self._device.status.attributes[Attribute.data].data["href"] == self._page:
             self.unit_state = self._device.status.attributes[Attribute.data].value[


### PR DESCRIPTION
Background: https://developers.home-assistant.io/blog/2022/06/14/number_entity_refactoring

Updated to override properties native_max_value, native_min_value, native_step, native_unit_of_measurement, native_value instead of max_value, min_value, step, unit_of_measurement, value and to override methods async_set_native_value and set_native_value instead of async_set_value and set_value.