### PR TITLE
Fix deprecations for hass 2022.10

### DIFF
--- a/custom_components/smartthings/number.py
+++ b/custom_components/smartthings/number.py
@@ -20,7 +20,7 @@ from homeassistant.const import PERCENTAGE, DEVICE_CLASS_TEMPERATURE
 
 Map = namedtuple(
     "map",
-    "attribute command name unit_of_measurement icon min_value max_value step mode",
+    "attribute command name native_unit_of_measurement icon native_min_value native_max_value native_step mode",
 )
 
 CAPABILITY_TO_NUMBER = {
@@ -54,11 +54,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         m.attribute,
                         m.command,
                         m.name,
-                        m.unit_of_measurement,
+                        m.native_unit_of_measurement,
                         m.icon,
-                        m.min_value,
-                        m.max_value,
-                        m.step,
+                        m.native_min_value,
+                        m.native_max_value,
+                        m.native_step,
                         m.mode,
                     )
                     for m in maps
@@ -106,11 +106,11 @@ class SmartThingsNumber(SmartThingsEntity, NumberEntity):
         attribute: str,
         command: str,
         name: str,
-        unit_of_measurement: str | None,
+        native_unit_of_measurement: str | None,
         icon: str | None,
-        min_value: str | None,
-        max_value: str | None,
-        step: str | None,
+        native_min_value: str | None,
+        native_max_value: str | None,
+        native_step: str | None,
         mode: str | None,
     ) -> None:
         """Init the class."""
@@ -118,14 +118,14 @@ class SmartThingsNumber(SmartThingsEntity, NumberEntity):
         self._attribute = attribute
         self._command = command
         self._name = name
-        self._attr_unit_of_measurement = unit_of_measurement
+        self._attr_native_unit_of_measurement = native_unit_of_measurement
         self._icon = icon
-        self._attr_min_value = min_value
-        self._attr_max_value = max_value
-        self._attr_step = step
+        self._attr_native_min_value = native_min_value
+        self._attr_native_max_value = native_max_value
+        self._attr_native_step = native_step
         self._attr_mode = mode
 
-    async def async_set_value(self, value: float) -> None:
+    async def async_set_native_value(self, value: float) -> None:
         """Set the number value."""
         await getattr(self._device, self._command)(int(value), set_status=True)
 
@@ -140,7 +140,7 @@ class SmartThingsNumber(SmartThingsEntity, NumberEntity):
         return f"{self._device.device_id}.{self._attribute}"
 
     @property
-    def value(self) -> float:
+    def native_value(self) -> float:
         """Return  Value."""
         return self._device.status.attributes[self._attribute].value
 
@@ -150,25 +150,25 @@ class SmartThingsNumber(SmartThingsEntity, NumberEntity):
         return self._icon
 
     @property
-    def min_value(self) -> float:
+    def native_min_value(self) -> float:
         """Define mimimum level."""
-        return self._attr_min_value
+        return self._attr_native_min_value
 
     @property
-    def max_value(self) -> float:
+    def native_max_value(self) -> float:
         """Define maximum level."""
-        return self._attr_max_value
+        return self._attr_native_max_value
 
     @property
-    def step(self) -> float:
+    def native_step(self) -> float:
         """Define stepping size"""
-        return self._attr_step
+        return self._attr_native_step
 
     @property
-    def unit_of_measurement(self) -> str | None:
+    def native_unit_of_measurement(self) -> str | None:
         """Return unit of measurement"""
         unit = self._device.status.attributes[self._attribute].unit
-        return UNIT_MAP.get(unit) if unit else self._attr_unit_of_measurement
+        return UNIT_MAP.get(unit) if unit else self._attr_native_unit_of_measurement
 
     @property
     def mode(self) -> Literal["auto", "slider", "box"]:
@@ -180,8 +180,8 @@ class SamsungOcfTemperatureNumber(SmartThingsEntity, NumberEntity):
     """Define a Samsung OCF Number."""
 
     execute_state = 0
-    min_value_state = 0
-    max_value_state = 0
+    native_min_value_state = 0
+    native_max_value_state = 0
     unit_state = ""
     init_bool = False
 
@@ -204,7 +204,7 @@ class SamsungOcfTemperatureNumber(SmartThingsEntity, NumberEntity):
         tasks.append(self._device.execute(self._page))
         asyncio.gather(*tasks)
 
-    async def async_set_value(self, value: float) -> None:
+    async def async_set_native_value(self, value: float) -> None:
         """Set the number value."""
         result = await self._device.execute(self._page, {"temperature": value})
         if result:
@@ -213,7 +213,7 @@ class SamsungOcfTemperatureNumber(SmartThingsEntity, NumberEntity):
                 {
                     "payload": {
                         "temperature": value,
-                        "range": [self.min_value_state, self.max_value_state],
+                        "range": [self.native_min_value_state, self.native_max_value_state],
                         "units": self.unit_state,
                     }
                 },
@@ -233,7 +233,7 @@ class SamsungOcfTemperatureNumber(SmartThingsEntity, NumberEntity):
         return f"{self._device.device_id}.{_unique_id}"
 
     @property
-    def value(self) -> float:
+    def native_value(self) -> float:
         """Return  Value."""
         if not self.init_bool:
             self.startup()
@@ -252,34 +252,34 @@ class SamsungOcfTemperatureNumber(SmartThingsEntity, NumberEntity):
         return "mdi:thermometer-lines"
 
     @property
-    def min_value(self) -> float:
+    def native_min_value(self) -> float:
         """Define mimimum level."""
         if self._device.status.attributes[Attribute.data].data["href"] == self._page:
-            self.min_value_state = int(
+            self.native_min_value_state = int(
                 self._device.status.attributes[Attribute.data].value["payload"][
                     "range"
                 ][0]
             )
-        return self.min_value_state
+        return self.native_min_value_state
 
     @property
-    def max_value(self) -> float:
+    def native_max_value(self) -> float:
         """Define maximum level."""
         if self._device.status.attributes[Attribute.data].data["href"] == self._page:
-            self.max_value_state = int(
+            self.native_max_value_state = int(
                 self._device.status.attributes[Attribute.data].value["payload"][
                     "range"
                 ][1]
             )
-        return self.max_value_state
+        return self.native_max_value_state
 
     @property
-    def step(self) -> float:
+    def native_step(self) -> float:
         """Define stepping size"""
         return 1
 
     @property
-    def unit_of_measurement(self) -> str | None:
+    def native_unit_of_measurement(self) -> str | None:
         """Return unit of measurement"""
         if self._device.status.attributes[Attribute.data].data["href"] == self._page:
             self.unit_state = self._device.status.attributes[Attribute.data].value[


### PR DESCRIPTION
This PR renames all updated properties and methods that are required for hass 2022.10.

Docs: https://developers.home-assistant.io/docs/core/entity/number/