### PR TITLE
Remove custom preset logic for airco heat mode

### DIFF
--- a/custom_components/smartthings/climate.py
+++ b/custom_components/smartthings/climate.py
@@ -527,7 +527,7 @@ class SmartThingsAirConditioner(SmartThingsEntity, ClimateEntity):
             supported_ac_optional_modes.append("quiet")
             self.is_faulty_quiet = True
 
-        if self._device.status.air_conditioner_mode in ("auto", "heat"):
+        if self._device.status.air_conditioner_mode == "auto":
             if any(
                 restrictedvalue in supported_ac_optional_modes
                 for restrictedvalue in restricted_values


### PR DESCRIPTION
My airco (ARTIK051_PRAC_20K) supports all preset modes just like cooling mode does. This PR enables presets to be changed when in heat mode.

I don't know if this PR is correct for other models of airco.