### PR TITLE
Add 22K_REF_LCD_FHUB7.0 model

### DIFF
--- a/custom_components/smartthings/binary_sensor.py
+++ b/custom_components/smartthings/binary_sensor.py
@@ -75,7 +75,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         SamsungCooktopBurner(device, "Cooktop Bottom Right", 16),
                     ]
                 )
-            elif model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K"):
+            elif model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K", "22K_REF_LCD_FHUB7.0"):
                 sensors.extend(
                     [
                         SamsungOcfDoorBinarySensor(

--- a/custom_components/smartthings/number.py
+++ b/custom_components/smartthings/number.py
@@ -72,7 +72,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             and device.type == "OCF"
         ):
             model = device.status.attributes[Attribute.mnmo].value.split("|")[0]
-            if model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K"):
+            if model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K", "22K_REF_LCD_FHUB7.0"):
                 numbers.extend(
                     [
                         SamsungOcfTemperatureNumber(

--- a/custom_components/smartthings/select.py
+++ b/custom_components/smartthings/select.py
@@ -84,7 +84,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     and "motionIndirect" in supported_ac_optional_modes
                 ):
                     selects.extend([SamsungACMotionSensorSaver(device)])
-                elif model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K"):
+                elif model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K", "22K_REF_LCD_FHUB7.0"):
                     selects.extend([SamsungOcfDeliModeSelect(device)])
     async_add_entities(selects)
 

--- a/custom_components/smartthings/sensor.py
+++ b/custom_components/smartthings/sensor.py
@@ -652,7 +652,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         ),
                     ]
                 )
-            elif model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K"):
+            elif model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K", "22K_REF_LCD_FHUB7.0"):
                 sensors.extend(
                     [
                         SamsungOcfTemperatureSensor(

--- a/custom_components/smartthings/switch.py
+++ b/custom_components/smartthings/switch.py
@@ -146,7 +146,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         )
                     ]
                 )
-            elif model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K"):
+            elif model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K", "22K_REF_LCD_FHUB7.0"):
                 switches.extend(
                     [
                         SamsungOcfSwitch(


### PR DESCRIPTION
Simple PR to add 22K_REF_LCD_FHUB7.0 fridge model to binary_sensor.py, number.py, select.py, sensor.py and switch.py