### PR TITLE
Switch to async_forward_entry_setups from async_setup_platforms.

### DIFF
--- a/custom_components/smartthings/__init__.py
+++ b/custom_components/smartthings/__init__.py
@@ -183,7 +183,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
         return False
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 


### PR DESCRIPTION
This update is required prior to the 2023.3 release. Reference: https://developers.home-assistant.io/blog/2022/07/08/config_entry_forwards/

Signed-off-by: Mark Baker <mark@vpost.net>