### PR TITLE
Fix to #81

### DIFF
--- a/custom_components/smartthings/binary_sensor.py
+++ b/custom_components/smartthings/binary_sensor.py
@@ -75,7 +75,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         SamsungCooktopBurner(device, "Cooktop Bottom Right", 16),
                     ]
                 )
-            elif model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K"):
+            elif model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K","TP1X_REF_21K"):
                 sensors.extend(
                     [
                         SamsungOcfDoorBinarySensor(

--- a/custom_components/smartthings/number.py
+++ b/custom_components/smartthings/number.py
@@ -72,7 +72,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             and device.type == "OCF"
         ):
             model = device.status.attributes[Attribute.mnmo].value.split("|")[0]
-            if model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K"):
+            if model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K","TP1X_REF_21K"):
                 numbers.extend(
                     [
                         SamsungOcfTemperatureNumber(

--- a/custom_components/smartthings/select.py
+++ b/custom_components/smartthings/select.py
@@ -84,7 +84,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                     and "motionIndirect" in supported_ac_optional_modes
                 ):
                     selects.extend([SamsungACMotionSensorSaver(device)])
-                elif model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K"):
+                elif model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K", "TP1X_REF_21K"):
                     selects.extend([SamsungOcfDeliModeSelect(device)])
     async_add_entities(selects)
 

--- a/custom_components/smartthings/sensor.py
+++ b/custom_components/smartthings/sensor.py
@@ -652,7 +652,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                         ),
                     ]
                 )
-            elif model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K"):
+            elif model in ("21K_REF_LCD_FHUB6.0", "ARTIK051_REF_17K","TP1X_REF_21K"):
                 sensors.extend(
                     [
                         SamsungOcfTemperatureSensor(


### PR DESCRIPTION
Added TP1X_REF_21 to the existing logic. Surfaces the following:

Sliders: 
- Cooler Setpoint
- Freeze Setpoint

Sensors:
- Cooler Door (contact)
- FlexZone Door (contact)
- Freezer Door (contact)
- Cooler Temperature
- Freezer Temperature

Deprecates:
- Contact (legacy - can be disabled)
- Temperature Measurement (unavailable - can be disabled)
- Thermostat Cooling Setpoint (unavailable - can be disabled)