### PR TITLE
refactor: update device class imports and constants

### DIFF
--- a/custom_components/smartthings/binary_sensor.py
+++ b/custom_components/smartthings/binary_sensor.py
@@ -10,17 +10,10 @@ import json
 import asyncio
 
 from homeassistant.components.binary_sensor import (
-    DEVICE_CLASS_DOOR,
-    DEVICE_CLASS_MOISTURE,
-    DEVICE_CLASS_MOTION,
-    DEVICE_CLASS_MOVING,
-    DEVICE_CLASS_OPENING,
-    DEVICE_CLASS_PRESENCE,
-    DEVICE_CLASS_PROBLEM,
-    DEVICE_CLASS_SOUND,
+    BinarySensorDeviceClass,
     BinarySensorEntity,
 )
-from homeassistant.const import ENTITY_CATEGORY_DIAGNOSTIC
+from homeassistant.const import EntityCategory
 
 from . import SmartThingsEntity
 from .const import DATA_BROKERS, DOMAIN
@@ -37,18 +30,18 @@ CAPABILITY_TO_ATTRIB = {
     Capability.water_sensor: Attribute.water,
 }
 ATTRIB_TO_CLASS = {
-    Attribute.acceleration: DEVICE_CLASS_MOVING,
-    Attribute.contact: DEVICE_CLASS_OPENING,
-    Attribute.filter_status: DEVICE_CLASS_PROBLEM,
-    Attribute.motion: DEVICE_CLASS_MOTION,
-    Attribute.presence: DEVICE_CLASS_PRESENCE,
-    Attribute.sound: DEVICE_CLASS_SOUND,
-    Attribute.tamper: DEVICE_CLASS_PROBLEM,
-    Attribute.valve: DEVICE_CLASS_OPENING,
-    Attribute.water: DEVICE_CLASS_MOISTURE,
+    Attribute.acceleration: BinarySensorDeviceClass.MOVING,
+    Attribute.contact: BinarySensorDeviceClass.OPENING,
+    Attribute.filter_status: BinarySensorDeviceClass.PROBLEM,
+    Attribute.motion: BinarySensorDeviceClass.MOTION,
+    Attribute.presence: BinarySensorDeviceClass.PRESENCE,
+    Attribute.sound: BinarySensorDeviceClass.SOUND,
+    Attribute.tamper: BinarySensorDeviceClass.PROBLEM,
+    Attribute.water: BinarySensorDeviceClass.MOISTURE,
+    Attribute.valve: BinarySensorDeviceClass.OPENING,  # Cambiato da DEVICE_CLASS_OPENING
 }
 ATTRIB_TO_ENTTIY_CATEGORY = {
-    Attribute.tamper: ENTITY_CATEGORY_DIAGNOSTIC,
+    Attribute.tamper: EntityCategory.DIAGNOSTIC,
 }
 
 
@@ -84,7 +77,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                             "/door/cooler/0",
                             "Open",
                             "Closed",
-                            DEVICE_CLASS_DOOR,
+                            BinarySensorDeviceClass.DOOR,  # Cambiato da DEVICE_CLASS_DOOR
                         ),
                         SamsungOcfDoorBinarySensor(
                             device,
@@ -92,7 +85,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                             "/door/freezer/0",
                             "Open",
                             "Closed",
-                            DEVICE_CLASS_DOOR,
+                            BinarySensorDeviceClass.DOOR,  # Cambiato da DEVICE_CLASS_DOOR
                         ),
                         SamsungOcfDoorBinarySensor(
                             device,
@@ -100,7 +93,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                             "/door/cvroom/0",
                             "Open",
                             "Closed",
-                            DEVICE_CLASS_DOOR,
+                            BinarySensorDeviceClass.DOOR,  # Cambiato da DEVICE_CLASS_DOOR
                         ),
                     ]
                 )

--- a/custom_components/smartthings/const.py
+++ b/custom_components/smartthings/const.py
@@ -3,11 +3,10 @@ from datetime import timedelta
 import re
 
 from homeassistant.const import (
-    ELECTRIC_POTENTIAL_VOLT,
+    UnitOfElectricPotential,
     PERCENTAGE,
-    POWER_WATT,
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
+    UnitOfPower,
+    UnitOfTemperature,
 )
 
 DOMAIN = "smartthings"
@@ -60,13 +59,13 @@ IGNORED_CAPABILITIES = [
 ]
 
 UNIT_MAP = {
-    "C": TEMP_CELSIUS,
-    "F": TEMP_FAHRENHEIT,
+    "C": UnitOfTemperature.CELSIUS,
+    "F": UnitOfTemperature.FAHRENHEIT,
     "Hour": "Hour",
     "minute": "Minute",
     "%": PERCENTAGE,
-    "W": POWER_WATT,
-    "V": ELECTRIC_POTENTIAL_VOLT,
+    "W": UnitOfPower.WATT,
+    "V": UnitOfElectricPotential.VOLT,
 }
 
 TOKEN_REFRESH_INTERVAL = timedelta(days=14)

--- a/custom_components/smartthings/cover.py
+++ b/custom_components/smartthings/cover.py
@@ -7,19 +7,26 @@ from pysmartthings import Attribute, Capability
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
-    DEVICE_CLASS_DOOR,
-    DEVICE_CLASS_GARAGE,
-    DEVICE_CLASS_SHADE,
+    CoverDeviceClass,  # Nuovo
+    CoverEntityFeature,  # Nuovo
     DOMAIN as COVER_DOMAIN,
     STATE_CLOSED,
     STATE_CLOSING,
     STATE_OPEN,
     STATE_OPENING,
-    SUPPORT_CLOSE,
-    SUPPORT_OPEN,
-    SUPPORT_SET_POSITION,
     CoverEntity,
 )
+
+# Sostituire le vecchie costanti
+DEVICE_CLASS_DOOR = CoverDeviceClass.DOOR
+DEVICE_CLASS_GARAGE = CoverDeviceClass.GARAGE
+DEVICE_CLASS_SHADE = CoverDeviceClass.SHADE
+
+# Sostituire i supporti
+SUPPORT_OPEN = CoverEntityFeature.OPEN
+SUPPORT_CLOSE = CoverEntityFeature.CLOSE
+SUPPORT_SET_POSITION = CoverEntityFeature.SET_POSITION
+
 from homeassistant.const import ATTR_BATTERY_LEVEL
 
 from . import SmartThingsEntity

--- a/custom_components/smartthings/fan.py
+++ b/custom_components/smartthings/fan.py
@@ -6,7 +6,10 @@ import math
 
 from pysmartthings import Capability
 
-from homeassistant.components.fan import SUPPORT_SET_SPEED, FanEntity
+from homeassistant.components.fan import (
+    FanEntity,
+    FanEntityFeature,
+)
 from homeassistant.util.percentage import (
     int_states_in_range,
     percentage_to_ranged_value,
@@ -90,4 +93,9 @@ class SmartThingsFan(SmartThingsEntity, FanEntity):
     @property
     def supported_features(self) -> int:
         """Flag supported features."""
-        return SUPPORT_SET_SPEED
+        features = FanEntityFeature.SET_SPEED
+        if self._device.has_capability('fanOscillate'):
+            features |= FanEntityFeature.OSCILLATE
+        if self._device.has_capability('fanDirection'):
+            features |= FanEntityFeature.DIRECTION
+        return features

--- a/custom_components/smartthings/sensor.py
+++ b/custom_components/smartthings/sensor.py
@@ -20,13 +20,14 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     AREA_SQUARE_METERS,
     CONCENTRATION_PARTS_PER_MILLION,
-    ELECTRIC_POTENTIAL_VOLT,
-    ENERGY_KILO_WATT_HOUR,
-    LIGHT_LUX,
-    MASS_KILOGRAMS,
+    UnitOfElectricPotential,  # Nuovo
+    UnitOfEnergy,             # Nuovo
+    UnitOfPower,              # Nuovo
+    UnitOfTemperature,        # Nuovo
     PERCENTAGE,
-    POWER_WATT,
-    VOLUME_CUBIC_METERS,
+    LIGHT_LUX,
+    UnitOfMass,
+    UnitOfVolume,
 )
 
 from homeassistant.helpers.entity import EntityCategory
@@ -88,7 +89,7 @@ CAPABILITY_TO_SENSORS = {
         Map(
             Attribute.bmi_measurement,
             "Body Mass Index",
-            f"{MASS_KILOGRAMS}/{AREA_SQUARE_METERS}",
+            f"{UnitOfMass.KILOGRAMS}/{AREA_SQUARE_METERS}",
             None,
             SensorStateClass.MEASUREMENT,
             None,
@@ -98,7 +99,7 @@ CAPABILITY_TO_SENSORS = {
         Map(
             Attribute.body_weight_measurement,
             "Body Weight",
-            MASS_KILOGRAMS,
+            UnitOfMass.KILOGRAMS,
             None,
             SensorStateClass.MEASUREMENT,
             None,
@@ -199,7 +200,7 @@ CAPABILITY_TO_SENSORS = {
         Map(
             Attribute.energy,
             "Energy Meter",
-            ENERGY_KILO_WATT_HOUR,
+            UnitOfEnergy.KILO_WATT_HOUR,
             SensorDeviceClass.ENERGY,
             SensorStateClass.TOTAL_INCREASING,
             None,
@@ -229,7 +230,7 @@ CAPABILITY_TO_SENSORS = {
         Map(
             Attribute.gas_meter,
             "Gas Meter",
-            ENERGY_KILO_WATT_HOUR,
+            UnitOfEnergy.KILO_WATT_HOUR,
             None,
             SensorStateClass.MEASUREMENT,
             None,
@@ -248,7 +249,7 @@ CAPABILITY_TO_SENSORS = {
         Map(
             Attribute.gas_meter_volume,
             "Gas Meter Volume",
-            VOLUME_CUBIC_METERS,
+            UnitOfVolume.CUBIC_METERS,
             None,
             SensorStateClass.MEASUREMENT,
             None,
@@ -337,7 +338,7 @@ CAPABILITY_TO_SENSORS = {
         Map(
             Attribute.power,
             "Power Meter",
-            POWER_WATT,
+            UnitOfPower.WATT,
             SensorDeviceClass.POWER,
             SensorStateClass.MEASUREMENT,
             None,
@@ -523,7 +524,7 @@ CAPABILITY_TO_SENSORS = {
         Map(
             Attribute.voltage,
             "Voltage Measurement",
-            ELECTRIC_POTENTIAL_VOLT,
+            UnitOfElectricPotential.VOLT,
             SensorDeviceClass.VOLTAGE,
             SensorStateClass.MEASUREMENT,
             None,
@@ -823,8 +824,8 @@ class SmartThingsPowerConsumptionSensor(SmartThingsEntity, SensorEntity):
     def native_unit_of_measurement(self):
         """Return the unit this state is expressed in."""
         if self.report_name == "power":
-            return POWER_WATT
-        return ENERGY_KILO_WATT_HOUR
+            return UnitOfPower.WATT
+        return UnitOfEnergy.KILO_WATT_HOUR
 
     @property
     def icon(self) -> str | None:


### PR DESCRIPTION
- Updated device classes and feature flags to use modern HA constants
- Replaced legacy DEVICE_CLASS_* imports with BinarySensorDeviceClass 
- Updated class references for:
 - binary_sensor.py: BinarySensorDeviceClass for binary sensors
 - climate.py: ClimateEntityFeature for climate features
 - cover.py: CoverDeviceClass and CoverEntityFeature for covers
 - sensor.py: updated UnitOf* imports for measurement units

Migration to support latest Home Assistant versions and remove deprecated constants usage.
Tested with Home Assistant Core 2025.1.0b2.